### PR TITLE
feat: add geolocation API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,11 @@ accuracy_radius: 1000
 timezone: Australia/Sydney
 city: Sydney
 postal_code: 2000
-subdivisions: [{"code":"NSW","name":"New South Wales"}]
-country: {"code":"AU","name":"Australia"}
-continent: {"code":"OC","name":"Oceania"}
+subdivisions: NSW (New South Wales)
+country_code: AU
+country_name: Australia
+continent_code: OC
+continent_name: Oceania
 is_in_european_union: false
 is_anonymous_proxy: false
 is_satellite_provider: false

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ JSON:
   "latitude": -33.8591,
   "longitude": 151.2002,
   "accuracy_radius": 1000,
+  "timezone": "Australia/Sydney",
   "city": "Sydney",
   "postal_code": "2000",
   "metro_code": null,
@@ -135,6 +136,7 @@ ip: 1.1.1.1
 latitude: -33.8591
 longitude: 151.2002
 accuracy_radius: 1000
+timezone: Australia/Sydney
 city: Sydney
 postal_code: 2000
 subdivisions: [{"code":"NSW","name":"New South Wales"}]

--- a/README.md
+++ b/README.md
@@ -120,9 +120,7 @@ JSON:
   "city": "Sydney",
   "postal_code": "2000",
   "metro_code": null,
-  "subdivisions": [
-    { "code": "NSW", "name": "New South Wales" }
-  ],
+  "subdivisions": [{ "code": "NSW", "name": "New South Wales" }],
   "country": { "code": "AU", "name": "Australia" },
   "continent": { "code": "OC", "name": "Oceania" },
   "is_in_european_union": false,

--- a/README.md
+++ b/README.md
@@ -22,13 +22,6 @@ Comparison of APIs that provide similar functionality.
 
 \* has been down multiple times in the past, and still suffers from occasional 'connection reset' errors.
 
-## Roadmap
-
-A couple of features that are planned for the future:
-
-- [ ] Provide additional geolocation data API endpoints (coordinates, country, city, etc.). We have the data, just not the API endpoints.
-- [Suggest a feature!](https://github.com/sleeyax/world-time-api/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen)
-
 ## Data Sources
 
 We use the following open data sources to provide accurate timezone information:
@@ -59,6 +52,13 @@ The API follows the World Time API specification with the following endpoints:
 - `GET /api/ip.txt` - Get time based on client IP (plain text)
 - `GET /api/ip/{ip}` - Get time based on specific IPv4 or IPv6 address (JSON)
 - `GET /api/ip/{ip}.txt` - Get time based on specific IPv4 or IPv6 address (plain text)
+
+### Geolocation Endpoints
+
+- `GET /api/geo` - Get geolocation data for client IP (JSON)
+- `GET /api/geo.txt` - Get geolocation data for client IP (plain text)
+- `GET /api/geo/{ip}` - Get geolocation data for specific IPv4 or IPv6 address (JSON)
+- `GET /api/geo/{ip}.txt` - Get geolocation data for specific IPv4 or IPv6 address (plain text)
 
 ## Response Formats
 
@@ -104,6 +104,43 @@ dst_offset: 3600
 dst_from: 2025-03-09T07:00:00+00:00
 dst_until: 2025-11-02T06:00:00+00:00
 client_ip: 127.0.0.1
+```
+
+### Geolocation
+
+JSON:
+
+```json
+{
+  "ip": "1.1.1.1",
+  "latitude": -33.8591,
+  "longitude": 151.2002,
+  "accuracy_radius": 1000,
+  "city": "Sydney",
+  "postal_code": "2000",
+  "metro_code": null,
+  "subdivisions": [
+    { "code": "NSW", "name": "New South Wales" }
+  ],
+  "country": { "code": "AU", "name": "Australia" },
+  "continent": { "code": "OC", "name": "Oceania" },
+  "is_in_european_union": false
+}
+```
+
+Plain Text:
+
+```
+ip: 1.1.1.1
+latitude: -33.8591
+longitude: 151.2002
+accuracy_radius: 1000
+city: Sydney
+postal_code: 2000
+subdivisions: [{"code":"NSW","name":"New South Wales"}]
+country: {"code":"AU","name":"Australia"}
+continent: {"code":"OC","name":"Oceania"}
+is_in_european_union: false
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -125,7 +125,10 @@ JSON:
   ],
   "country": { "code": "AU", "name": "Australia" },
   "continent": { "code": "OC", "name": "Oceania" },
-  "is_in_european_union": false
+  "is_in_european_union": false,
+  "is_anonymous_proxy": false,
+  "is_satellite_provider": false,
+  "is_anycast": false
 }
 ```
 
@@ -143,6 +146,9 @@ subdivisions: [{"code":"NSW","name":"New South Wales"}]
 country: {"code":"AU","name":"Australia"}
 continent: {"code":"OC","name":"Oceania"}
 is_in_european_union: false
+is_anonymous_proxy: false
+is_satellite_provider: false
+is_anycast: false
 ```
 
 ## Development

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -423,10 +423,11 @@ paths:
                 timezone: Australia/Sydney
                 city: Sydney
                 postal_code: 2000
-                metro_code:
-                subdivisions: [{"code":"NSW","name":"New South Wales"}]
-                country: {"code":"AU","name":"Australia"}
-                continent: {"code":"OC","name":"Oceania"}
+                subdivisions: NSW (New South Wales)
+                country_code: AU
+                country_name: Australia
+                continent_code: OC
+                continent_name: Oceania
                 is_in_european_union: false
                 is_anonymous_proxy: false
                 is_satellite_provider: false
@@ -520,10 +521,11 @@ paths:
                 timezone: Australia/Sydney
                 city: Sydney
                 postal_code: 2000
-                metro_code:
-                subdivisions: [{"code":"NSW","name":"New South Wales"}]
-                country: {"code":"AU","name":"Australia"}
-                continent: {"code":"OC","name":"Oceania"}
+                subdivisions: NSW (New South Wales)
+                country_code: AU
+                country_name: Australia
+                continent_code: OC
+                continent_name: Oceania
                 is_in_european_union: false
                 is_anonymous_proxy: false
                 is_satellite_provider: false

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -383,6 +383,7 @@ paths:
                 latitude: -33.8591
                 longitude: 151.2002
                 accuracy_radius: 1000
+                timezone: "Australia/Sydney"
                 city: "Sydney"
                 postal_code: "2000"
                 metro_code: null
@@ -416,6 +417,7 @@ paths:
                 latitude: -33.8591
                 longitude: 151.2002
                 accuracy_radius: 1000
+                timezone: Australia/Sydney
                 city: Sydney
                 postal_code: 2000
                 metro_code:
@@ -458,6 +460,7 @@ paths:
                 latitude: -33.8591
                 longitude: 151.2002
                 accuracy_radius: 1000
+                timezone: "Australia/Sydney"
                 city: "Sydney"
                 postal_code: "2000"
                 metro_code: null
@@ -505,6 +508,7 @@ paths:
                 latitude: -33.8591
                 longitude: 151.2002
                 accuracy_radius: 1000
+                timezone: Australia/Sydney
                 city: Sydney
                 postal_code: 2000
                 metro_code:
@@ -953,6 +957,7 @@ components:
         - latitude
         - longitude
         - accuracy_radius
+        - timezone
         - city
         - postal_code
         - metro_code
@@ -980,6 +985,11 @@ components:
           nullable: true
           description: >-
             accuracy radius in kilometers
+        timezone:
+          type: string
+          nullable: true
+          description: >-
+            timezone in `Area/Location` or `Area/Location/Region` format
         city:
           type: string
           nullable: true

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -397,6 +397,9 @@ paths:
                   code: "OC"
                   name: "Oceania"
                 is_in_european_union: false
+                is_anonymous_proxy: false
+                is_satellite_provider: false
+                is_anycast: false
         default:
           $ref: "#/components/responses/ErrorJsonResponse"
   /geo.txt:
@@ -425,6 +428,9 @@ paths:
                 country: {"code":"AU","name":"Australia"}
                 continent: {"code":"OC","name":"Oceania"}
                 is_in_european_union: false
+                is_anonymous_proxy: false
+                is_satellite_provider: false
+                is_anycast: false
         default:
           $ref: "#/components/responses/ErrorTextResponse"
 
@@ -474,6 +480,9 @@ paths:
                   code: "OC"
                   name: "Oceania"
                 is_in_european_union: false
+                is_anonymous_proxy: false
+                is_satellite_provider: false
+                is_anycast: false
         default:
           $ref: "#/components/responses/ErrorJsonResponse"
   /geo/{ip}.txt:
@@ -516,6 +525,9 @@ paths:
                 country: {"code":"AU","name":"Australia"}
                 continent: {"code":"OC","name":"Oceania"}
                 is_in_european_union: false
+                is_anonymous_proxy: false
+                is_satellite_provider: false
+                is_anycast: false
         default:
           $ref: "#/components/responses/ErrorTextResponse"
 
@@ -965,6 +977,9 @@ components:
         - country
         - continent
         - is_in_european_union
+        - is_anonymous_proxy
+        - is_satellite_provider
+        - is_anycast
       properties:
         ip:
           type: string
@@ -1047,6 +1062,18 @@ components:
           type: boolean
           description: >-
             whether the location is in the European Union
+        is_anonymous_proxy:
+          type: boolean
+          description: >-
+            whether the IP belongs to an anonymous proxy (VPN, Tor, etc.)
+        is_satellite_provider:
+          type: boolean
+          description: >-
+            whether the IP belongs to a satellite internet provider
+        is_anycast:
+          type: boolean
+          description: >-
+            whether the IP is an anycast address
 
     GeoTextResponse:
       type: string

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -365,6 +365,156 @@ paths:
                 client_ip: "127.0.0.1"
         default:
           $ref: "#/components/responses/ErrorJsonResponse"
+  /geo:
+    get:
+      summary: >-
+        request geolocation data based on the ip of the request.
+        note: this is a "best guess" obtained from open-source data.
+      responses:
+        "200":
+          description: >-
+            geolocation data for the client IP in JSON format
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeoJsonResponse"
+              example:
+                ip: "1.1.1.1"
+                latitude: -33.8591
+                longitude: 151.2002
+                accuracy_radius: 1000
+                city: "Sydney"
+                postal_code: "2000"
+                metro_code: null
+                subdivisions:
+                  - code: "NSW"
+                    name: "New South Wales"
+                country:
+                  code: "AU"
+                  name: "Australia"
+                continent:
+                  code: "OC"
+                  name: "Oceania"
+                is_in_european_union: false
+        default:
+          $ref: "#/components/responses/ErrorJsonResponse"
+  /geo.txt:
+    get:
+      summary: >-
+        request geolocation data based on the ip of the request.
+        note: this is a "best guess" obtained from open-source data.
+      responses:
+        "200":
+          description: >-
+            geolocation data for the client IP in plain text
+          content:
+            text/plain:
+              schema:
+                $ref: "#/components/schemas/GeoTextResponse"
+              example: |
+                ip: 1.1.1.1
+                latitude: -33.8591
+                longitude: 151.2002
+                accuracy_radius: 1000
+                city: Sydney
+                postal_code: 2000
+                metro_code:
+                subdivisions: [{"code":"NSW","name":"New South Wales"}]
+                country: {"code":"AU","name":"Australia"}
+                continent: {"code":"OC","name":"Oceania"}
+                is_in_european_union: false
+        default:
+          $ref: "#/components/responses/ErrorTextResponse"
+
+  /geo/{ip}:
+    get:
+      summary: >-
+        request geolocation data for a specific IPv4 or IPv6 address.
+        note: this is a "best guess" obtained from open-source data.
+      parameters:
+        - name: ip
+          in: path
+          required: true
+          description: IPv4 or IPv6 address
+          schema:
+            type: string
+          examples:
+            ipv4:
+              value: "1.1.1.1"
+              summary: IPv4 address
+            ipv6:
+              value: "2606:4700:4700::1111"
+              summary: IPv6 address (Cloudflare DNS)
+      responses:
+        "200":
+          description: >-
+            geolocation data for the specified IP in JSON format
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeoJsonResponse"
+              example:
+                ip: "1.1.1.1"
+                latitude: -33.8591
+                longitude: 151.2002
+                accuracy_radius: 1000
+                city: "Sydney"
+                postal_code: "2000"
+                metro_code: null
+                subdivisions:
+                  - code: "NSW"
+                    name: "New South Wales"
+                country:
+                  code: "AU"
+                  name: "Australia"
+                continent:
+                  code: "OC"
+                  name: "Oceania"
+                is_in_european_union: false
+        default:
+          $ref: "#/components/responses/ErrorJsonResponse"
+  /geo/{ip}.txt:
+    get:
+      summary: >-
+        request geolocation data for a specific IPv4 or IPv6 address.
+        note: this is a "best guess" obtained from open-source data.
+      parameters:
+        - name: ip
+          in: path
+          required: true
+          description: IPv4 or IPv6 address
+          schema:
+            type: string
+          examples:
+            ipv4:
+              value: "1.1.1.1"
+              summary: IPv4 address
+            ipv6:
+              value: "2606:4700:4700::1111"
+              summary: IPv6 address (Cloudflare DNS)
+      responses:
+        "200":
+          description: >-
+            geolocation data for the specified IP in plain text
+          content:
+            text/plain:
+              schema:
+                $ref: "#/components/schemas/GeoTextResponse"
+              example: |
+                ip: 1.1.1.1
+                latitude: -33.8591
+                longitude: 151.2002
+                accuracy_radius: 1000
+                city: Sydney
+                postal_code: 2000
+                metro_code:
+                subdivisions: [{"code":"NSW","name":"New South Wales"}]
+                country: {"code":"AU","name":"Australia"}
+                continent: {"code":"OC","name":"Oceania"}
+                is_in_european_union: false
+        default:
+          $ref: "#/components/responses/ErrorTextResponse"
+
   /ip/{ip}.txt:
     get:
       summary: >-
@@ -780,3 +930,116 @@ components:
       type: string
       description: >-
         details about the error encountered in plain text
+
+    GeoSubdivision:
+      type: object
+      required:
+        - code
+        - name
+      properties:
+        code:
+          type: string
+          description: >-
+            ISO 3166-2 subdivision code
+        name:
+          type: string
+          description: >-
+            subdivision name
+
+    GeoJsonResponse:
+      type: object
+      required:
+        - ip
+        - latitude
+        - longitude
+        - accuracy_radius
+        - city
+        - postal_code
+        - metro_code
+        - subdivisions
+        - country
+        - continent
+        - is_in_european_union
+      properties:
+        ip:
+          type: string
+          description: >-
+            the IP address that was looked up
+        latitude:
+          type: number
+          nullable: true
+          description: >-
+            latitude coordinate
+        longitude:
+          type: number
+          nullable: true
+          description: >-
+            longitude coordinate
+        accuracy_radius:
+          type: integer
+          nullable: true
+          description: >-
+            accuracy radius in kilometers
+        city:
+          type: string
+          nullable: true
+          description: >-
+            city name
+        postal_code:
+          type: string
+          nullable: true
+          description: >-
+            postal code
+        metro_code:
+          type: integer
+          nullable: true
+          description: >-
+            metro code (US only)
+        subdivisions:
+          type: array
+          description: >-
+            list of subdivisions (e.g., states, provinces)
+          items:
+            $ref: "#/components/schemas/GeoSubdivision"
+        country:
+          type: object
+          required:
+            - code
+            - name
+          properties:
+            code:
+              type: string
+              nullable: true
+              description: >-
+                ISO 3166-1 alpha-2 country code
+            name:
+              type: string
+              nullable: true
+              description: >-
+                country name
+        continent:
+          type: object
+          required:
+            - code
+            - name
+          properties:
+            code:
+              type: string
+              nullable: true
+              description: >-
+                two-letter continent code
+            name:
+              type: string
+              nullable: true
+              description: >-
+                continent name
+        is_in_european_union:
+          type: boolean
+          description: >-
+            whether the location is in the European Union
+
+    GeoTextResponse:
+      type: string
+      description: >-
+        geolocation details, as per the GeoJsonResponse
+        response, in the format `key: value`, one item per line

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { WorkerEntrypoint } from "cloudflare:workers";
 import { timezoneRouter } from "./routes/timezone";
 import { ipRouter } from "./routes/ip";
+import { geoRouter } from "./routes/geo";
 import { HonoApp, Bindings } from "./types/api";
 import { clientIpMiddleware } from "./middleware/client-ip";
 import { HTTPException } from "hono/http-exception";
@@ -47,6 +48,7 @@ app.use("*", rapidAPIMiddleware);
 // Apply IP middleware to world time API routes only.
 app.use("/api/timezone/*", clientIpMiddleware);
 app.use("/api/ip/*", clientIpMiddleware);
+app.use("/api/geo/*", clientIpMiddleware);
 
 // Convert any call to an URL that ends with .txt to a text response.
 app.use("/api/*", textResponseMiddleware);
@@ -58,6 +60,7 @@ app.get("/", (c) => {
 });
 app.route("/api", timezoneRouter);
 app.route("/api", ipRouter);
+app.route("/api", geoRouter);
 app.route("/api", healthRouter);
 
 export default class WorldTimeApi extends WorkerEntrypoint<Bindings> {

--- a/src/routes/geo.ts
+++ b/src/routes/geo.ts
@@ -1,0 +1,57 @@
+import { Hono } from "hono";
+import { GeoJsonResponse, HonoApp } from "../types/api";
+import { HTTPException } from "hono/http-exception";
+import { getClientIp } from "../services/ip";
+import { ipToGeoLocation } from "../services/geo";
+import { AddressError } from "ip-address";
+
+export const geoRouter = new Hono<HonoApp>();
+
+// GET /geo - Get geo data for client IP
+geoRouter.on("GET", ["/geo", "/geo.txt"], async (c) => {
+  const clientIp = getClientIp(c);
+  if (!clientIp) {
+    throw new HTTPException(400, {
+      message: "Client IP not detected",
+    });
+  }
+
+  const response = await ipToGeoLocation(c.env.DB, clientIp);
+  if (!response) {
+    throw new HTTPException(404, {
+      message: `Couldn't find geo data for IP ${clientIp}`,
+    });
+  }
+
+  return c.json(response);
+});
+
+// GET /geo/:ip - Get geo data for specific IP
+geoRouter.on("GET", ["/geo/:ip", "/geo/:ip.txt"], async (c) => {
+  const ip = c.req.param("ip").replace(/\.txt$/, "");
+  if (!ip) {
+    throw new HTTPException(400, {
+      message: "IP parameter is required",
+    });
+  }
+
+  let response: GeoJsonResponse | null;
+
+  try {
+    response = await ipToGeoLocation(c.env.DB, ip);
+    if (!response) {
+      throw new HTTPException(404, {
+        message: `Couldn't find geo data for IP ${ip}`,
+      });
+    }
+  } catch (error) {
+    if (error instanceof AddressError) {
+      throw new HTTPException(400, {
+        message: "malformed ip",
+      });
+    }
+    throw error;
+  }
+
+  return c.json(response);
+});

--- a/src/routes/geo.ts
+++ b/src/routes/geo.ts
@@ -47,7 +47,7 @@ geoRouter.on("GET", ["/geo/:ip", "/geo/:ip.txt"], async (c) => {
   } catch (error) {
     if (error instanceof AddressError) {
       throw new HTTPException(400, {
-        message: "malformed ip",
+        message: "Malformed IP",
       });
     }
     throw error;

--- a/src/services/geo.ts
+++ b/src/services/geo.ts
@@ -5,6 +5,7 @@ function toBool(value: string | number | boolean | null | undefined): boolean {
   if (value === null || value === undefined) return false;
   if (typeof value === "boolean") return value;
   if (typeof value === "number") return value !== 0;
+  if (value === "0") return false;
   return value === "true" || value === "1";
 }
 

--- a/src/services/geo.ts
+++ b/src/services/geo.ts
@@ -1,6 +1,13 @@
 import { ipToBinary } from "../utils/ip";
 import { GeoJsonResponse, GeoSubdivision } from "../types/api";
 
+function toBool(value: string | number | boolean | null | undefined): boolean {
+  if (value === null || value === undefined) return false;
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value !== 0;
+  return value === "true" || value === "1";
+}
+
 interface GeoRow {
   latitude: number | null;
   longitude: number | null;
@@ -17,16 +24,16 @@ interface GeoRow {
   country_name: string | null;
   continent_code: string | null;
   continent_name: string | null;
-  is_in_european_union: number | null;
-  is_anonymous_proxy: number | null;
-  is_satellite_provider: number | null;
-  is_anycast: number | null;
+  is_in_european_union: string | number | boolean | null;
+  is_anonymous_proxy: string | number | boolean | null;
+  is_satellite_provider: string | number | boolean | null;
+  is_anycast: string | number | boolean | null;
   // Fallback fields from registered_country
   registered_country_iso_code: string | null;
   registered_country_name: string | null;
   registered_continent_code: string | null;
   registered_continent_name: string | null;
-  registered_is_in_european_union: number | null;
+  registered_is_in_european_union: string | number | boolean | null;
   registered_time_zone: string | null;
 }
 
@@ -107,7 +114,7 @@ limit 1;
   const continentCode = row.continent_code || row.registered_continent_code;
   const continentName = row.continent_name || row.registered_continent_name;
   const isInEu =
-    row.is_in_european_union ?? row.registered_is_in_european_union ?? 0;
+    row.is_in_european_union ?? row.registered_is_in_european_union;
   const timezone = row.time_zone || row.registered_time_zone;
 
   return {
@@ -128,9 +135,9 @@ limit 1;
       code: continentCode,
       name: continentName,
     },
-    is_in_european_union: Boolean(isInEu),
-    is_anonymous_proxy: Boolean(row.is_anonymous_proxy),
-    is_satellite_provider: Boolean(row.is_satellite_provider),
-    is_anycast: Boolean(row.is_anycast),
+    is_in_european_union: toBool(isInEu),
+    is_anonymous_proxy: toBool(row.is_anonymous_proxy),
+    is_satellite_provider: toBool(row.is_satellite_provider),
+    is_anycast: toBool(row.is_anycast),
   };
 }

--- a/src/services/geo.ts
+++ b/src/services/geo.ts
@@ -18,6 +18,9 @@ interface GeoRow {
   continent_code: string | null;
   continent_name: string | null;
   is_in_european_union: number | null;
+  is_anonymous_proxy: number | null;
+  is_satellite_provider: number | null;
+  is_anycast: number | null;
   // Fallback fields from registered_country
   registered_country_iso_code: string | null;
   registered_country_name: string | null;
@@ -41,6 +44,9 @@ select
   net.longitude,
   net.accuracy_radius,
   net.postal_code,
+  net.is_anonymous_proxy,
+  net.is_satellite_provider,
+  net.is_anycast,
   location.city_name,
   location.metro_code,
   location.time_zone,
@@ -123,5 +129,8 @@ limit 1;
       name: continentName,
     },
     is_in_european_union: Boolean(isInEu),
+    is_anonymous_proxy: Boolean(row.is_anonymous_proxy),
+    is_satellite_provider: Boolean(row.is_satellite_provider),
+    is_anycast: Boolean(row.is_anycast),
   };
 }

--- a/src/services/geo.ts
+++ b/src/services/geo.ts
@@ -1,0 +1,121 @@
+import { ipToBinary } from "../utils/ip";
+import { GeoJsonResponse, GeoSubdivision } from "../types/api";
+
+interface GeoRow {
+  latitude: number | null;
+  longitude: number | null;
+  accuracy_radius: number | null;
+  postal_code: string | null;
+  city_name: string | null;
+  metro_code: number | null;
+  subdivision_1_iso_code: string | null;
+  subdivision_1_name: string | null;
+  subdivision_2_iso_code: string | null;
+  subdivision_2_name: string | null;
+  country_iso_code: string | null;
+  country_name: string | null;
+  continent_code: string | null;
+  continent_name: string | null;
+  is_in_european_union: number | null;
+  // Fallback fields from registered_country
+  registered_country_iso_code: string | null;
+  registered_country_name: string | null;
+  registered_continent_code: string | null;
+  registered_continent_name: string | null;
+  registered_is_in_european_union: number | null;
+}
+
+export async function ipToGeoLocation(
+  db: D1Database,
+  ip: string,
+): Promise<GeoJsonResponse | null> {
+  const ipBuffer = ipToBinary(ip);
+
+  const row = await db
+    .prepare(
+      `
+select
+  net.latitude,
+  net.longitude,
+  net.accuracy_radius,
+  net.postal_code,
+  location.city_name,
+  location.metro_code,
+  location.subdivision_1_iso_code,
+  location.subdivision_1_name,
+  location.subdivision_2_iso_code,
+  location.subdivision_2_name,
+  location.country_iso_code,
+  location.country_name,
+  location.continent_code,
+  location.continent_name,
+  location.is_in_european_union,
+  registered_country.country_iso_code as registered_country_iso_code,
+  registered_country.country_name as registered_country_name,
+  registered_country.continent_code as registered_continent_code,
+  registered_country.continent_name as registered_continent_name,
+  registered_country.is_in_european_union as registered_is_in_european_union
+from
+  geoip2_network net
+left join geoip2_location location on (
+  net.geoname_id = location.geoname_id and location.locale_code = 'en'
+)
+left join geoip2_location registered_country on (
+  net.registered_country_geoname_id = registered_country.geoname_id
+  and registered_country.locale_code = 'en'
+)
+where ? between net.network_start and net.network_end
+order by net.network_end
+limit 1;
+`,
+    )
+    .bind(ipBuffer)
+    .first<GeoRow | null>();
+
+  if (!row) {
+    return null;
+  }
+
+  // Build subdivisions array, filtering out nulls
+  const subdivisions: GeoSubdivision[] = [];
+  if (row.subdivision_1_iso_code && row.subdivision_1_name) {
+    subdivisions.push({
+      code: row.subdivision_1_iso_code,
+      name: row.subdivision_1_name,
+    });
+  }
+  if (row.subdivision_2_iso_code && row.subdivision_2_name) {
+    subdivisions.push({
+      code: row.subdivision_2_iso_code,
+      name: row.subdivision_2_name,
+    });
+  }
+
+  // Use fallbacks from registered_country if primary lookup fails
+  const countryCode = row.country_iso_code || row.registered_country_iso_code;
+  const countryName = row.country_name || row.registered_country_name;
+  const continentCode = row.continent_code || row.registered_continent_code;
+  const continentName = row.continent_name || row.registered_continent_name;
+  const isInEu =
+    row.is_in_european_union ?? row.registered_is_in_european_union ?? 0;
+
+  return {
+    ip,
+    latitude: row.latitude,
+    longitude: row.longitude,
+    accuracy_radius: row.accuracy_radius,
+    city: row.city_name,
+    postal_code: row.postal_code,
+    metro_code: row.metro_code,
+    subdivisions,
+    country: {
+      code: countryCode,
+      name: countryName,
+    },
+    continent: {
+      code: continentCode,
+      name: continentName,
+    },
+    is_in_european_union: Boolean(isInEu),
+  };
+}

--- a/src/services/geo.ts
+++ b/src/services/geo.ts
@@ -8,6 +8,7 @@ interface GeoRow {
   postal_code: string | null;
   city_name: string | null;
   metro_code: number | null;
+  time_zone: string | null;
   subdivision_1_iso_code: string | null;
   subdivision_1_name: string | null;
   subdivision_2_iso_code: string | null;
@@ -23,6 +24,7 @@ interface GeoRow {
   registered_continent_code: string | null;
   registered_continent_name: string | null;
   registered_is_in_european_union: number | null;
+  registered_time_zone: string | null;
 }
 
 export async function ipToGeoLocation(
@@ -41,6 +43,7 @@ select
   net.postal_code,
   location.city_name,
   location.metro_code,
+  location.time_zone,
   location.subdivision_1_iso_code,
   location.subdivision_1_name,
   location.subdivision_2_iso_code,
@@ -54,7 +57,8 @@ select
   registered_country.country_name as registered_country_name,
   registered_country.continent_code as registered_continent_code,
   registered_country.continent_name as registered_continent_name,
-  registered_country.is_in_european_union as registered_is_in_european_union
+  registered_country.is_in_european_union as registered_is_in_european_union,
+  registered_country.time_zone as registered_time_zone
 from
   geoip2_network net
 left join geoip2_location location on (
@@ -98,12 +102,14 @@ limit 1;
   const continentName = row.continent_name || row.registered_continent_name;
   const isInEu =
     row.is_in_european_union ?? row.registered_is_in_european_union ?? 0;
+  const timezone = row.time_zone || row.registered_time_zone;
 
   return {
     ip,
     latitude: row.latitude,
     longitude: row.longitude,
     accuracy_radius: row.accuracy_radius,
+    timezone,
     city: row.city_name,
     postal_code: row.postal_code,
     metro_code: row.metro_code,

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -29,6 +29,31 @@ export interface ErrorJsonResponse {
 
 export type ErrorTextResponse = string;
 
+export interface GeoSubdivision {
+  code: string;
+  name: string;
+}
+
+export interface GeoJsonResponse {
+  ip: string;
+  latitude: number | null;
+  longitude: number | null;
+  accuracy_radius: number | null;
+  city: string | null;
+  postal_code: string | null;
+  metro_code: number | null;
+  subdivisions: GeoSubdivision[];
+  country: {
+    code: string | null;
+    name: string | null;
+  };
+  continent: {
+    code: string | null;
+    name: string | null;
+  };
+  is_in_european_union: boolean;
+}
+
 // Request parameter types
 export interface TimezoneParams {
   area: string;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -53,6 +53,9 @@ export interface GeoJsonResponse {
     name: string | null;
   };
   is_in_european_union: boolean;
+  is_anonymous_proxy: boolean;
+  is_satellite_provider: boolean;
+  is_anycast: boolean;
 }
 
 // Request parameter types

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -39,6 +39,7 @@ export interface GeoJsonResponse {
   latitude: number | null;
   longitude: number | null;
   accuracy_radius: number | null;
+  timezone: string | null;
   city: string | null;
   postal_code: string | null;
   metro_code: number | null;

--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -1,17 +1,49 @@
-function valueToString(value: any): string {
-  if (value === null || value === undefined) {
-    return "";
+function formatArrayValue(arr: any[]): string {
+  if (arr.length === 0) return "";
+
+  // Handle array of objects with code/name (e.g., subdivisions)
+  if (typeof arr[0] === "object" && arr[0] !== null) {
+    return arr
+      .map((item) => {
+        if (item.code && item.name) {
+          return `${item.code} (${item.name})`;
+        }
+        return JSON.stringify(item);
+      })
+      .join(", ");
   }
-  if (typeof value === "object") {
-    return JSON.stringify(value);
+
+  // Simple array of primitives
+  return arr.join(", ");
+}
+
+function flattenObject(
+  obj: any,
+  prefix: string = "",
+): Array<[string, string]> {
+  const result: Array<[string, string]> = [];
+
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === null || value === undefined) continue;
+
+    const fullKey = prefix ? `${prefix}_${key}` : key;
+
+    if (Array.isArray(value)) {
+      result.push([fullKey, formatArrayValue(value)]);
+    } else if (typeof value === "object") {
+      // Flatten nested object
+      result.push(...flattenObject(value, fullKey));
+    } else {
+      result.push([fullKey, String(value)]);
+    }
   }
-  return String(value);
+
+  return result;
 }
 
 function objectToString(obj: any): string {
-  return Object.entries(obj)
-    .filter(([_, value]) => value != null)
-    .map(([key, value]) => `${key}: ${valueToString(value)}`)
+  return flattenObject(obj)
+    .map(([key, value]) => `${key}: ${value}`)
     .join("\n");
 }
 

--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -1,7 +1,17 @@
+function valueToString(value: any): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
+
 function objectToString(obj: any): string {
   return Object.entries(obj)
     .filter(([_, value]) => value != null)
-    .map(([key, value]) => `${key}: ${value}`)
+    .map(([key, value]) => `${key}: ${valueToString(value)}`)
     .join("\n");
 }
 

--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -26,7 +26,9 @@ function flattenObject(obj: any, prefix: string = ""): Array<[string, string]> {
     const fullKey = prefix ? `${prefix}_${key}` : key;
 
     if (Array.isArray(value)) {
-      result.push([fullKey, formatArrayValue(value)]);
+      const formatted = formatArrayValue(value);
+      if (formatted === "") continue;
+      result.push([fullKey, formatted]);
     } else if (typeof value === "object") {
       // Flatten nested object
       result.push(...flattenObject(value, fullKey));

--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -17,10 +17,7 @@ function formatArrayValue(arr: any[]): string {
   return arr.join(", ");
 }
 
-function flattenObject(
-  obj: any,
-  prefix: string = "",
-): Array<[string, string]> {
+function flattenObject(obj: any, prefix: string = ""): Array<[string, string]> {
   const result: Array<[string, string]> = [];
 
   for (const [key, value] of Object.entries(obj)) {


### PR DESCRIPTION
Introduce new geolocation endpoints for retrieving client IP geolocation data, including additional fields for timezone, proxy, and provider information. Optimized txt response formatting and handles boolean values correctly in the responses.