### PR TITLE
feat: add enterprise API keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,8 +11,4 @@ CLOUDFLARE_D1_DATABASE_ID=value_from_wrangler_config
 # Rapid API
 RAPID_API_SECRET=your_rapid_api_key_here
 
-# Master keys for direct (non-RapidAPI) access.
-# Comma-separated name:key pairs. Name is used only for log tracing.
-# MASTER_KEYS=internal-dashboard:abc123,mobile-app:def456
-
 NODE_ENV=development

--- a/README.md
+++ b/README.md
@@ -206,6 +206,58 @@ npx wrangler d1 execute geolite2 --remote --file=./schema.sql
 npm run download:geo -- --chunk-size 250000 --split-files
 ```
 
+## Enterprise keys
+
+Enterprise keys grant direct (non-RapidAPI) access and live in a dedicated `enterprise` D1 database, separate from the geo `geolite2` database.
+Callers authenticate with the `x-enterprise-key` header.
+Each key has an optional monthly request limit (`request_limit`; `null` = unlimited); over-limit requests get a `429` and don't consume quota.
+Limited responses carry `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset`.
+
+One-time setup (creates the database and its schema):
+
+```bash
+# Create the database, then paste the returned database_id into wrangler.jsonc (ENTERPRISE_DB).
+npx wrangler d1 create enterprise
+
+# Apply the schema (local, then remote when deploying).
+npx wrangler d1 execute enterprise --local --file=./schema-enterprise.sql
+npx wrangler d1 execute enterprise --remote --file=./schema-enterprise.sql
+```
+
+Add a key (the raw key is shown to the customer once and never stored, only its hash is):
+
+```bash
+# 1. Generate a strong random raw key into a variable, and print it (give THIS to the customer).
+KEY=$(openssl rand -hex 32); echo "$KEY"
+
+# 2. Hash it (this is what goes in the DB).
+HASH=$(printf '%s' "$KEY" | sha256sum | cut -d' ' -f1); echo "$HASH"
+
+# 3. Insert the hash. request_limit is the monthly cap; use NULL for unlimited.
+#    2000000 below = 1 million requests/month. Add --remote to target production.
+npx wrangler d1 execute enterprise --local \
+  --command "insert into enterprise_keys (key_hash, name, request_limit) values ('$HASH', 'unknown key', 1000000);"
+```
+
+Admin operations (run against the `enterprise` DB; changes can take up to 24h to take effect on warm isolates due to the in-isolate config cache so redeploy to flush immediately):
+
+```bash
+# Change a limit (or set NULL for unlimited)
+update enterprise_keys set request_limit = 5000000 where name = '<name>';
+# Revoke a key
+delete from enterprise_keys where name = '<name>';
+# Inspect usage
+select * from enterprise_key_usage where period = '2026-06';
+```
+
+### Test a key
+
+Use `$KEY` from step 1, or paste the raw key. Auth is bypassed when `NODE_ENV=development`, so unset it to exercise this path locally. `-i` prints the `X-RateLimit-*` headers:
+
+```bash
+curl -i -H "x-enterprise-key: $KEY" http://localhost:8787/api/timezone/Europe/Amsterdam
+```
+
 ## License
 
 This project is licensed under the BSL 1.1 license, with a change date of `three years from release date` after which the license automatically changes to GPL v3. See [LICENSE](./LICENSE) for details.

--- a/schema-enterprise.sql
+++ b/schema-enterprise.sql
@@ -1,0 +1,16 @@
+-- Schema for the dedicated `enterprise` D1 database (enterprise keys + usage).
+
+create table if not exists enterprise_keys (
+  key_hash text primary key,   -- sha-256 hex of the raw key
+  name text not null,          -- label, for log tracing only
+  request_limit int,           -- max requests per calendar month; null = unlimited
+  created_at text not null default (datetime('now'))
+);
+
+-- One row per (key, month). Hot-write counter, kept separate from the config above.
+create table if not exists enterprise_key_usage (
+  key_hash text not null,
+  period text not null,        -- 'YYYY-MM' (UTC)
+  count int not null default 0,
+  primary key (key_hash, period)
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ app.notFound((c) => {
   );
 });
 
-// Authenticate incoming requests (RapidAPI proxy secret or master key).
+// Authenticate incoming requests (RapidAPI proxy secret or enterprise key).
 app.use("*", authMiddleware);
 
 // Apply IP middleware to world time API routes only.

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,22 +1,117 @@
-import { MiddlewareHandler } from "hono";
+import { Context, MiddlewareHandler } from "hono";
 import { HTTPException } from "hono/http-exception";
+import { HonoApp } from "../types/api";
+import {
+  monthlyPeriod,
+  periodResetEpoch,
+  rateLimitHeaders,
+  sha256Hex,
+} from "../utils/enterprise-key";
 
-const masterKeys = parseMasterKeys(process.env.MASTER_KEYS);
+// Cache resolved key config per isolate to avoid a D1 read on every request.
+// Keys rarely change; a stale window of up to TTL is acceptable. Redeploy to flush immediately.
+const ENTERPRISE_KEY_TTL_MS = 24 * 60 * 60 * 1000;
 
-function parseMasterKeys(raw: string | undefined): Map<string, string> {
-  const map = new Map<string, string>();
-  if (!raw) return map;
-  for (const pair of raw.split(",")) {
-    const idx = pair.indexOf(":");
-    if (idx <= 0) continue;
-    const name = pair.slice(0, idx).trim();
-    const key = pair.slice(idx + 1).trim();
-    if (name && key) map.set(key, name);
+type CachedKey = {
+  hash: string;
+  name: string;
+  limit: number | null;
+  expires: number;
+};
+
+const enterpriseKeyCache = new Map<string, CachedKey>();
+
+type Usage = {
+  allowed: boolean;
+  count: number;
+  limit: number | null;
+  reset: number;
+};
+
+// Resolve a raw key to its config via cache, falling back to a D1 lookup by hash.
+// Only cache hits; misses are not cached (random invalid keys would grow the cache unbounded).
+async function lookupEnterpriseKey(
+  db: D1Database,
+  rawKey: string,
+): Promise<CachedKey | null> {
+  const cached = enterpriseKeyCache.get(rawKey);
+  if (cached && cached.expires > Date.now()) {
+    return cached;
   }
-  return map;
+
+  const hash = await sha256Hex(rawKey);
+  const row = await db
+    .prepare(
+      "select name, request_limit from enterprise_keys where key_hash = ?",
+    )
+    .bind(hash)
+    .first<{ name: string; request_limit: number | null }>();
+
+  if (!row) return null;
+
+  const record: CachedKey = {
+    hash,
+    name: row.name,
+    limit: row.request_limit,
+    expires: Date.now() + ENTERPRISE_KEY_TTL_MS,
+  };
+  enterpriseKeyCache.set(rawKey, record);
+  return record;
 }
 
-export const authMiddleware: MiddlewareHandler = async (c, next) => {
+// Meter the request and decide whether it's allowed.
+// Only allowed requests increment the counter (a 429'd request does not consume quota).
+async function recordUsageAndCheck(
+  db: D1Database,
+  hash: string,
+  limit: number | null,
+): Promise<Usage> {
+  const period = monthlyPeriod(new Date());
+  const reset = periodResetEpoch(period);
+
+  // A non-positive limit grants nothing; reject without a write (such a key should be revoked).
+  if (limit !== null && limit <= 0) {
+    return { allowed: false, count: 0, limit, reset };
+  }
+
+  if (limit === null) {
+    // Unlimited: meter for visibility, always allow.
+    const row = await db
+      .prepare(
+        "insert into enterprise_key_usage (key_hash, period, count) values (?, ?, 1) on conflict(key_hash, period) do update set count = count + 1 returning count",
+      )
+      .bind(hash, period)
+      .first<{ count: number }>();
+    return { allowed: true, count: row?.count ?? 1, limit, reset };
+  }
+
+  // Limited: conditional atomic increment. A row is returned only when it actually counted.
+  const row = await db
+    .prepare(
+      "insert into enterprise_key_usage (key_hash, period, count) values (?, ?, 1) on conflict(key_hash, period) do update set count = count + 1 where count < ? returning count",
+    )
+    .bind(hash, period, limit)
+    .first<{ count: number }>();
+
+  if (row) {
+    return { allowed: true, count: row.count, limit, reset };
+  }
+
+  // No row -> the `where count < limit` guard blocked the update (already at the cap).
+  return { allowed: false, count: limit, limit, reset };
+}
+
+// Emit rate-limit headers for limited keys only (unlimited keys are metered but unbounded).
+// Called after next() so downstream response rebuilds don't drop them.
+function setRateLimitHeaders(c: Context<HonoApp>, usage: Usage): void {
+  if (usage.limit === null) return;
+  const headers = rateLimitHeaders(usage.limit, usage.count, usage.reset);
+  for (const [name, value] of Object.entries(headers)) {
+    c.res.headers.set(name, value);
+  }
+}
+
+export const authMiddleware: MiddlewareHandler<HonoApp> = async (c, next) => {
   if (c.req.path === "/api/ping") {
     return next();
   }
@@ -25,12 +120,27 @@ export const authMiddleware: MiddlewareHandler = async (c, next) => {
     return next();
   }
 
-  const masterKey = c.req.header("x-master-key");
-  if (masterKey) {
-    const name = masterKeys.get(masterKey);
-    if (name) {
-      console.log(`auth: master key '${name}'`);
-      return next();
+  const enterpriseKey = c.req.header("x-enterprise-key");
+  if (enterpriseKey) {
+    const record = await lookupEnterpriseKey(
+      c.env.ENTERPRISE_DB,
+      enterpriseKey,
+    );
+    if (record) {
+      console.log(`auth: enterprise key '${record.name}'`);
+      const usage = await recordUsageAndCheck(
+        c.env.ENTERPRISE_DB,
+        record.hash,
+        record.limit,
+      );
+      if (!usage.allowed) {
+        // Over quota: short-circuit with a 429 (no fall-through to RapidAPI).
+        setRateLimitHeaders(c, usage);
+        return c.json({ error: "Monthly request limit exceeded" }, 429);
+      }
+      await next();
+      setRateLimitHeaders(c, usage);
+      return;
     }
   }
 

--- a/src/middleware/text-response.ts
+++ b/src/middleware/text-response.ts
@@ -11,12 +11,11 @@ export const textResponseMiddleware: MiddlewareHandler = async (c, next) => {
     try {
       const jsonBody = await c.res.json();
       const textBody = formatAsText(jsonBody);
+      const headers = new Headers(c.res.headers);
+      headers.set("Content-Type", "text/plain");
       c.res = new Response(textBody, {
         status: c.res.status,
-        headers: new Headers({
-          ...c.res.headers,
-          "Content-Type": "text/plain",
-        }),
+        headers,
       });
     } catch (_) {
       // skip errors

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -97,5 +97,6 @@ export type IpHandler = (
 export type HonoApp = { Bindings: Bindings };
 
 export type Bindings = {
-  DB: D1Database;
+  DB: D1Database; // geolite2 (unchanged)
+  ENTERPRISE_DB: D1Database; // enterprise keys + usage
 };

--- a/src/utils/enterprise-key.test.ts
+++ b/src/utils/enterprise-key.test.ts
@@ -1,0 +1,55 @@
+import { expect, describe, it } from "vitest";
+import {
+  sha256Hex,
+  monthlyPeriod,
+  periodResetEpoch,
+  rateLimitHeaders,
+} from "./enterprise-key";
+
+describe("sha256Hex", () => {
+  it("matches a known vector", async () => {
+    expect(await sha256Hex("abc")).toBe(
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    );
+  });
+});
+
+describe("monthlyPeriod", () => {
+  it("returns the UTC YYYY-MM bucket", () => {
+    expect(monthlyPeriod(new Date("2026-06-08T12:00:00Z"))).toBe("2026-06");
+  });
+});
+
+describe("periodResetEpoch", () => {
+  it("returns the first instant of the next month, UTC", () => {
+    expect(periodResetEpoch("2026-06")).toBe(Date.UTC(2026, 6, 1) / 1000);
+  });
+
+  it("rolls December over to January of the next year", () => {
+    expect(periodResetEpoch("2026-12")).toBe(Date.UTC(2027, 0, 1) / 1000);
+  });
+});
+
+describe("rateLimitHeaders", () => {
+  const reset = 1234567890;
+
+  it("reports remaining below the limit", () => {
+    expect(rateLimitHeaders(100, 40, reset)).toEqual({
+      "X-RateLimit-Limit": "100",
+      "X-RateLimit-Remaining": "60",
+      "X-RateLimit-Reset": String(reset),
+    });
+  });
+
+  it("reports 0 remaining at the limit", () => {
+    expect(rateLimitHeaders(100, 100, reset)["X-RateLimit-Remaining"]).toBe(
+      "0",
+    );
+  });
+
+  it("clamps remaining to 0 over the limit", () => {
+    expect(rateLimitHeaders(100, 150, reset)["X-RateLimit-Remaining"]).toBe(
+      "0",
+    );
+  });
+});

--- a/src/utils/enterprise-key.ts
+++ b/src/utils/enterprise-key.ts
@@ -1,0 +1,58 @@
+/**
+ * Computes the SHA-256 digest of `input` as a lowercase hex string.
+ * Used to hash raw keys before comparing them against the DB.
+ *
+ * @param input - The string to hash.
+ * @returns The 64-character lowercase hex digest.
+ */
+export async function sha256Hex(input: string): Promise<string> {
+  const bytes = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/**
+ * Returns the UTC calendar-month bucket for `now`, formatted as `YYYY-MM`.
+ *
+ * @param now - The instant to bucket.
+ * @returns The `YYYY-MM` period string.
+ */
+export function monthlyPeriod(now: Date): string {
+  return now.toISOString().slice(0, 7);
+}
+
+/**
+ * Returns the UTC epoch seconds of the first instant of the month *after* `period`.
+ * e.g. `'2026-06'` -> 2026-07-01T00:00:00Z, `'2026-12'` -> 2027-01-01T00:00:00Z.
+ *
+ * @param period - A `YYYY-MM` period string.
+ * @returns The reset time as epoch seconds.
+ */
+export function periodResetEpoch(period: string): number {
+  const [year, month] = period.split("-").map(Number);
+  // `month` is 1-based; Date.UTC month is 0-based, so passing `month` yields the next month.
+  return Date.UTC(year, month, 1) / 1000;
+}
+
+/**
+ * Builds the `X-RateLimit-*` headers for a metered (limited) key.
+ * Remaining is clamped to 0.
+ *
+ * @param limit - The monthly request limit.
+ * @param count - Requests consumed so far this period.
+ * @param reset - Reset time as epoch seconds (see {@link periodResetEpoch}).
+ * @returns A map of rate-limit header names to values.
+ */
+export function rateLimitHeaders(
+  limit: number,
+  count: number,
+  reset: number,
+): Record<string, string> {
+  return {
+    "X-RateLimit-Limit": String(limit),
+    "X-RateLimit-Remaining": String(Math.max(0, limit - count)),
+    "X-RateLimit-Reset": String(reset),
+  };
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -26,6 +26,11 @@
       "database_name": "geolite2",
       "database_id": "60e0c742-1506-462b-bd94-674a0fb101f3",
     },
+    {
+      "binding": "ENTERPRISE_DB",
+      "database_name": "enterprise",
+      "database_id": "70289f70-d6c9-4ea7-872b-983d7cb7f5a0",
+    },
   ],
   // "ai": {
   //   "binding": "AI"


### PR DESCRIPTION
Add proper enterprise API keys via D1 database instead of hard-coded keys in environment variables.