### PR TITLE
Draft: feat: auto-provision enterprise keys from Whop subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,36 @@ Use `$KEY` from step 1, or paste the raw key. Auth is bypassed when `NODE_ENV=de
 curl -i -H "x-enterprise-key: $KEY" http://localhost:8787/api/timezone/Europe/Amsterdam
 ```
 
+### Whop subscriptions
+
+Individual subscriptions sold through [Whop](https://whop.com) provision and revoke enterprise keys automatically, so you don't run the SQL above by hand for them.
+We reuse the **license key Whop already issues per membership**: on subscribe we store its hash as an enterprise key; the customer reads the key from their Whop dashboard and sends it as the usual `x-enterprise-key` header.
+The raw key is never stored, only its hash (same model as manual keys).
+
+`POST /webhooks/whop` receives Whop's `membership.activated` / `membership.deactivated` events, verified via the [`@whop/sdk`](https://www.npmjs.com/package/@whop/sdk) Standard-Webhooks signature check.
+On activate we look the product up in `whop_plans`; **only products listed there grant access** (a row is the allowlist), with `request_limit` as the monthly cap (`null` = unlimited).
+On deactivate we delete the key. Revocation is subject to the same up-to-24h warm-isolate cache as manual keys.
+
+Prerequisite: each API-granting Whop product must use the **License Key** delivery type so the webhook payload carries a `license_key`.
+
+Setup:
+
+```bash
+# 1. Apply the schema
+npx wrangler d1 execute enterprise --remote --file=./schema-enterprise.sql
+
+# 2. Map each API-granting Whop product (prod_...) to its monthly limit (NULL = unlimited).
+npx wrangler d1 execute enterprise --remote \
+  --command "insert into whop_plans (product_id, request_limit) values ('prod_xxx', 1000000);"
+
+# 3. Store the webhook signing secret from the Whop dashboard.
+npx wrangler secret put WHOP_WEBHOOK_SECRET
+```
+
+In the Whop dashboard, point a webhook at `https://<your-worker>/webhooks/whop`, subscribed to `membership.activated` and `membership.deactivated`.
+
+To test locally, expose `wrangler dev` with a tunnel (e.g. `cloudflared tunnel --url http://localhost:8787`), set the dashboard webhook to the tunnel URL, put its signing secret in `.dev.vars` as `WHOP_WEBHOOK_SECRET`, then use the dashboard's **Send test webhook** button.
+
 ## License
 
 This project is licensed under the BSL 1.1 license, with a change date of `three years from release date` after which the license automatically changes to GPL v3. See [LICENSE](./LICENSE) for details.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "BSL-1.1",
       "dependencies": {
+        "@whop/sdk": "^0.0.40",
         "hono": "^4.8.10",
         "ip-address": "^10.0.1",
         "timezonecomplete": "5.15.0",
@@ -23,6 +24,7 @@
         "csv-parser": "^3.2.0",
         "dotenv": "^17.2.1",
         "prettier": "3.6.2",
+        "standardwebhooks": "^1.0.0",
         "tsx": "^4.20.3",
         "typescript": "^5.8.3",
         "unzipper": "^0.12.3",
@@ -1367,6 +1369,12 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/chai": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
@@ -1535,6 +1543,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@whop/sdk": {
+      "version": "0.0.40",
+      "resolved": "https://registry.npmjs.org/@whop/sdk/-/sdk-0.0.40.tgz",
+      "integrity": "sha512-hTZHVEo7IN6O+bU06Bbde5eDh6EDIoJ22hs5VdDXHKf/tMOvA9IMlGQeWeyDhXXUg2fvUQ3LQ+7qxGxs7JXPOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jose": "^6.1.0",
+        "standardwebhooks": "^1.0.0"
       }
     },
     "node_modules/abort-controller": {
@@ -2034,6 +2052,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fdir": {
       "version": "6.4.6",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
@@ -2282,6 +2306,15 @@
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/js-tokens": {
       "version": "9.0.1",
@@ -2770,6 +2803,16 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
     },
     "node_modules/std-env": {
       "version": "3.9.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "license": "BSL-1.1",
   "type": "module",
   "dependencies": {
+    "@whop/sdk": "^0.0.40",
     "hono": "^4.8.10",
     "ip-address": "^10.0.1",
     "timezonecomplete": "5.15.0",
@@ -39,6 +40,7 @@
     "csv-parser": "^3.2.0",
     "dotenv": "^17.2.1",
     "prettier": "3.6.2",
+    "standardwebhooks": "^1.0.0",
     "tsx": "^4.20.3",
     "typescript": "^5.8.3",
     "unzipper": "^0.12.3",

--- a/schema-enterprise.sql
+++ b/schema-enterprise.sql
@@ -4,8 +4,15 @@ create table if not exists enterprise_keys (
   key_hash text primary key,   -- sha-256 hex of the raw key
   name text not null,          -- label, for log tracing only
   request_limit int,           -- max requests per calendar month; null = unlimited
+  whop_membership_id text,     -- source Whop membership (mem_...); null for manually-created keys
   created_at text not null default (datetime('now'))
 );
+
+-- At most one key per Whop membership.
+-- Partial index so multiple manual keys (whop_membership_id is null) don't collide.
+create unique index if not exists idx_enterprise_keys_whop_membership
+  on enterprise_keys (whop_membership_id)
+  where whop_membership_id is not null;
 
 -- One row per (key, month). Hot-write counter, kept separate from the config above.
 create table if not exists enterprise_key_usage (
@@ -13,4 +20,11 @@ create table if not exists enterprise_key_usage (
   period text not null,        -- 'YYYY-MM' (UTC)
   count int not null default 0,
   primary key (key_hash, period)
+);
+
+-- Whop product (access_pass, prod_...) -> monthly request limit.
+-- A row's existence is the allowlist: only products listed here grant API access on subscribe.
+create table if not exists whop_plans (
+  product_id text primary key, -- Whop product id (prod_...)
+  request_limit int            -- max requests per calendar month; null = unlimited
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { clientIpMiddleware } from "./middleware/client-ip";
 import { HTTPException } from "hono/http-exception";
 import { textResponseMiddleware } from "./middleware/text-response";
 import { healthRouter } from "./routes/health";
+import { whopWebhookRouter } from "./routes/whop-webhook";
 import { authMiddleware } from "./middleware/auth";
 import { ipToTimezone } from "./services/ip";
 import { getTime } from "./services/timezone";
@@ -62,6 +63,7 @@ app.route("/api", timezoneRouter);
 app.route("/api", ipRouter);
 app.route("/api", geoRouter);
 app.route("/api", healthRouter);
+app.route("/webhooks", whopWebhookRouter);
 
 export default class WorldTimeApi extends WorkerEntrypoint<Bindings> {
   // Hono requests.

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -112,7 +112,7 @@ function setRateLimitHeaders(c: Context<HonoApp>, usage: Usage): void {
 }
 
 export const authMiddleware: MiddlewareHandler<HonoApp> = async (c, next) => {
-  if (c.req.path === "/api/ping") {
+  if (c.req.path === "/api/ping" || c.req.path === "/webhooks/whop") {
     return next();
   }
 

--- a/src/routes/whop-webhook.test.ts
+++ b/src/routes/whop-webhook.test.ts
@@ -1,0 +1,146 @@
+import { expect, describe, it } from "vitest";
+import { Webhook } from "standardwebhooks";
+import { whopWebhookRouter, handleWhopEvent } from "./whop-webhook";
+
+// No SDK mock: we sign requests for real with the same lib the SDK verifies with,
+// so the tests exercise actual signature verification end-to-end.
+const SECRET = "test-webhook-secret";
+// The route passes `btoa(secret)` as the webhookKey, so sign with the matching key.
+const signer = new Webhook(btoa(SECRET));
+
+type Call = { sql: string; binds: unknown[] };
+
+function mockDb(opts: { firstResults?: unknown[]; runChanges?: number }): {
+  db: D1Database;
+  calls: Call[];
+} {
+  const calls: Call[] = [];
+  const firstQueue = [...(opts.firstResults ?? [])];
+  const db = {
+    prepare(sql: string) {
+      const stmt = {
+        bind(...binds: unknown[]) {
+          calls.push({ sql, binds });
+          return stmt;
+        },
+        async first() {
+          return firstQueue.shift() ?? null;
+        },
+        async run() {
+          return { meta: { changes: opts.runChanges ?? 0 } };
+        },
+      };
+      return stmt;
+    },
+  } as unknown as D1Database;
+  return { db, calls };
+}
+
+function env(db: D1Database) {
+  return { ENTERPRISE_DB: db, WHOP_WEBHOOK_SECRET: SECRET } as never;
+}
+
+// Build a request whose body is correctly signed (optionally tampered to force a failure).
+function signedRequest(
+  payload: unknown,
+  { tamper = false }: { tamper?: boolean } = {},
+): RequestInit {
+  const body = JSON.stringify(payload);
+  const id = "msg_test";
+  const timestamp = new Date();
+  const signature = tamper ? "v1,AAAA" : signer.sign(id, timestamp, body);
+  return {
+    method: "POST",
+    body,
+    headers: {
+      "content-type": "application/json",
+      "webhook-id": id,
+      "webhook-timestamp": String(Math.floor(timestamp.getTime() / 1000)),
+      "webhook-signature": signature,
+    },
+  };
+}
+
+const activated = (overrides: Record<string, unknown> = {}) =>
+  ({
+    type: "membership.activated",
+    data: {
+      id: "mem_1",
+      product: { id: "prod_1" },
+      license_key: "LIC-ABC",
+      ...overrides,
+    },
+  }) as never;
+
+const deactivated = () =>
+  ({ type: "membership.deactivated", data: { id: "mem_1" } }) as never;
+
+describe("handleWhopEvent", () => {
+  it("provisions a key on membership.activated", async () => {
+    const { db, calls } = mockDb({
+      firstResults: [{ request_limit: 1000 }],
+      runChanges: 1,
+    });
+    await handleWhopEvent(env(db), activated());
+    expect(
+      calls.some((c) => c.sql.includes("insert into enterprise_keys")),
+    ).toBe(true);
+  });
+
+  it("revokes a key on membership.deactivated", async () => {
+    const { db, calls } = mockDb({ runChanges: 1 });
+    await handleWhopEvent(env(db), deactivated());
+    expect(
+      calls.some((c) => c.sql.includes("delete from enterprise_keys")),
+    ).toBe(true);
+  });
+
+  it("ignores unrelated events without touching the db", async () => {
+    const { db, calls } = mockDb({});
+    await handleWhopEvent(env(db), {
+      type: "payment.created",
+      data: {},
+    } as never);
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe("POST /whop", () => {
+  it("rejects a tampered signature with 401 and no writes", async () => {
+    const { db, calls } = mockDb({});
+    const res = await whopWebhookRouter.request(
+      "/whop",
+      signedRequest(activated(), { tamper: true }),
+      env(db),
+    );
+    expect(res.status).toBe(401);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("acks 200 and provisions on a valid activated webhook", async () => {
+    const { db, calls } = mockDb({
+      firstResults: [{ request_limit: 1000 }],
+      runChanges: 1,
+    });
+    const res = await whopWebhookRouter.request(
+      "/whop",
+      signedRequest(activated()),
+      env(db),
+    );
+    expect(res.status).toBe(200);
+    expect(
+      calls.some((c) => c.sql.includes("insert into enterprise_keys")),
+    ).toBe(true);
+  });
+
+  it("acks 200 on an unmapped product without provisioning", async () => {
+    const { db, calls } = mockDb({ firstResults: [] });
+    const res = await whopWebhookRouter.request(
+      "/whop",
+      signedRequest(activated({ product: { id: "prod_unknown" } })),
+      env(db),
+    );
+    expect(res.status).toBe(200);
+    expect(calls.some((c) => c.sql.includes("insert into"))).toBe(false);
+  });
+});

--- a/src/routes/whop-webhook.ts
+++ b/src/routes/whop-webhook.ts
@@ -1,0 +1,78 @@
+import { Hono } from "hono";
+import { Whop } from "@whop/sdk";
+import { HonoApp, Bindings } from "../types/api";
+import { provisionKey, revokeKey } from "../services/whop";
+
+// The discriminated union returned by the SDK's signature-verifying `unwrap`.
+type WhopEvent = ReturnType<Whop["webhooks"]["unwrap"]>;
+
+export const whopWebhookRouter = new Hono<HonoApp>();
+
+/**
+ * Routes a verified Whop webhook to key provisioning/revocation.
+ * Whop collapses payment, cancellation, expiry, refund and chargeback into membership
+ * validity transitions, so only the two activation events drive the key lifecycle.
+ * Every branch is an idempotent ack; D1 errors bubble up to the global handler (-> 5xx, Whop retries).
+ */
+export async function handleWhopEvent(
+  env: Bindings,
+  event: WhopEvent,
+): Promise<void> {
+  switch (event.type) {
+    case "membership.activated": {
+      const m = event.data;
+      const result = await provisionKey(env.ENTERPRISE_DB, {
+        membershipId: m.id,
+        productId: m.product.id,
+        licenseKey: m.license_key,
+      });
+      if (result === "provisioned") {
+        console.log(
+          `whop: provisioned key for membership '${m.id}' (product ${m.product.id})`,
+        );
+      } else if (result === "unmapped_product") {
+        console.log(
+          `whop: ignoring activation for unmapped product '${m.product.id}' (membership ${m.id})`,
+        );
+      } else {
+        console.error(
+          `whop: membership '${m.id}' has no license_key; configure the product for License Key delivery`,
+        );
+      }
+      return;
+    }
+    case "membership.deactivated": {
+      const m = event.data;
+      const revoked = await revokeKey(env.ENTERPRISE_DB, m.id);
+      console.log(
+        `whop: ${revoked ? "revoked" : "no matching"} key for deactivated membership '${m.id}'`,
+      );
+      return;
+    }
+    default:
+      // Subscribed-but-unhandled event; ack so Whop stops retrying.
+      console.log(`whop: ignoring event '${event.type}'`);
+  }
+}
+
+whopWebhookRouter.post("/whop", async (c) => {
+  const body = await c.req.text();
+  const headers = Object.fromEntries(c.req.raw.headers);
+
+  const whop = new Whop({
+    apiKey: c.env.WHOP_API_KEY ?? "unused",
+    webhookKey: btoa(c.env.WHOP_WEBHOOK_SECRET),
+  });
+
+  let event: WhopEvent;
+  try {
+    event = whop.webhooks.unwrap(body, { headers });
+  } catch (err) {
+    console.warn("whop: webhook signature verification failed", err);
+    return c.json({ error: "Invalid webhook signature" }, 401);
+  }
+
+  await handleWhopEvent(c.env, event);
+
+  return c.json({ ok: true });
+});

--- a/src/services/whop.test.ts
+++ b/src/services/whop.test.ts
@@ -1,0 +1,119 @@
+import { expect, describe, it } from "vitest";
+import { resolveProductLimit, provisionKey, revokeKey } from "./whop";
+import { sha256Hex } from "../utils/enterprise-key";
+
+type Call = { sql: string; binds: unknown[] };
+
+// Minimal D1 stub: queues `.first()` results and a single `.run()` result, records every bind.
+function mockDb(opts: { firstResults?: unknown[]; runChanges?: number }): {
+  db: D1Database;
+  calls: Call[];
+} {
+  const calls: Call[] = [];
+  const firstQueue = [...(opts.firstResults ?? [])];
+
+  const db = {
+    prepare(sql: string) {
+      const stmt = {
+        bind(...binds: unknown[]) {
+          calls.push({ sql, binds });
+          return stmt;
+        },
+        async first() {
+          return firstQueue.shift() ?? null;
+        },
+        async run() {
+          return { meta: { changes: opts.runChanges ?? 0 } };
+        },
+      };
+      return stmt;
+    },
+  } as unknown as D1Database;
+
+  return { db, calls };
+}
+
+describe("resolveProductLimit", () => {
+  it("returns the finite limit for a mapped product", async () => {
+    const { db } = mockDb({ firstResults: [{ request_limit: 1000 }] });
+    expect(await resolveProductLimit(db, "prod_1")).toBe(1000);
+  });
+
+  it("returns null for a mapped but unlimited product", async () => {
+    const { db } = mockDb({ firstResults: [{ request_limit: null }] });
+    expect(await resolveProductLimit(db, "prod_1")).toBeNull();
+  });
+
+  it("returns undefined for an unmapped product", async () => {
+    const { db } = mockDb({ firstResults: [] });
+    expect(await resolveProductLimit(db, "prod_unknown")).toBeUndefined();
+  });
+});
+
+describe("provisionKey", () => {
+  it("inserts the hashed license key with an upsert and membership label", async () => {
+    const { db, calls } = mockDb({
+      firstResults: [{ request_limit: 1000 }],
+      runChanges: 1,
+    });
+
+    const result = await provisionKey(db, {
+      membershipId: "mem_1",
+      productId: "prod_1",
+      licenseKey: "LIC-ABC",
+    });
+
+    expect(result).toBe("provisioned");
+    const insert = calls.find((c) =>
+      c.sql.includes("insert into enterprise_keys"),
+    );
+    expect(insert).toBeDefined();
+    expect(insert!.sql).toContain("on conflict(key_hash) do update");
+    expect(insert!.binds).toEqual([
+      await sha256Hex("LIC-ABC"),
+      "whop:mem_1",
+      1000,
+      "mem_1",
+    ]);
+  });
+
+  it("skips unmapped products without inserting", async () => {
+    const { db, calls } = mockDb({ firstResults: [] });
+
+    const result = await provisionKey(db, {
+      membershipId: "mem_1",
+      productId: "prod_unknown",
+      licenseKey: "LIC-ABC",
+    });
+
+    expect(result).toBe("unmapped_product");
+    expect(calls.some((c) => c.sql.includes("insert into"))).toBe(false);
+  });
+
+  it("skips memberships missing a license key", async () => {
+    const { db, calls } = mockDb({ firstResults: [{ request_limit: 1000 }] });
+
+    const result = await provisionKey(db, {
+      membershipId: "mem_1",
+      productId: "prod_1",
+      licenseKey: null,
+    });
+
+    expect(result).toBe("missing_license_key");
+    expect(calls.some((c) => c.sql.includes("insert into"))).toBe(false);
+  });
+});
+
+describe("revokeKey", () => {
+  it("returns true when a key was deleted", async () => {
+    const { db, calls } = mockDb({ runChanges: 1 });
+    expect(await revokeKey(db, "mem_1")).toBe(true);
+    expect(calls[0].sql).toContain("delete from enterprise_keys");
+    expect(calls[0].binds).toEqual(["mem_1"]);
+  });
+
+  it("returns false when no key matched", async () => {
+    const { db } = mockDb({ runChanges: 0 });
+    expect(await revokeKey(db, "mem_missing")).toBe(false);
+  });
+});

--- a/src/services/whop.ts
+++ b/src/services/whop.ts
@@ -1,0 +1,80 @@
+import { sha256Hex } from "../utils/enterprise-key";
+
+// Outcome of attempting to provision a key for a membership.
+// All outcomes are non-error acks; only the first actually grants access.
+export type ProvisionResult =
+  | "provisioned" // key created or refreshed
+  | "unmapped_product" // product not in whop_plans -> no key (allowlist miss)
+  | "missing_license_key"; // membership has no Whop license key (product not License-Key delivery)
+
+/**
+ * Resolves a Whop product's monthly request limit from `whop_plans`.
+ *
+ * @returns the limit (`number`), `null` for an explicitly unlimited product,
+ *          or `undefined` when the product is not listed (not API-granting).
+ */
+export async function resolveProductLimit(
+  db: D1Database,
+  productId: string,
+): Promise<number | null | undefined> {
+  const row = await db
+    .prepare("select request_limit from whop_plans where product_id = ?")
+    .bind(productId)
+    .first<{ request_limit: number | null }>();
+
+  // `null` row -> unmapped product; `null` request_limit -> mapped but unlimited.
+  return row ? row.request_limit : undefined;
+}
+
+/**
+ * Provisions (or refreshes) an enterprise key for a Whop membership.
+ * We store only the SHA-256 hash of the Whop-issued license key, never the key itself.
+ * Idempotent: re-firing for the same membership/license key upserts the limit by `key_hash`.
+ */
+export async function provisionKey(
+  db: D1Database,
+  params: {
+    membershipId: string;
+    productId: string;
+    licenseKey: string | null;
+  },
+): Promise<ProvisionResult> {
+  const limit = await resolveProductLimit(db, params.productId);
+  if (limit === undefined) {
+    return "unmapped_product";
+  }
+  if (!params.licenseKey) {
+    return "missing_license_key";
+  }
+
+  const hash = await sha256Hex(params.licenseKey);
+  await db
+    .prepare(
+      `insert into enterprise_keys (key_hash, name, request_limit, whop_membership_id)
+       values (?, ?, ?, ?)
+       on conflict(key_hash) do update set
+         request_limit = excluded.request_limit,
+         whop_membership_id = excluded.whop_membership_id`,
+    )
+    .bind(hash, `whop:${params.membershipId}`, limit, params.membershipId)
+    .run();
+
+  return "provisioned";
+}
+
+/**
+ * Revokes the enterprise key tied to a Whop membership.
+ *
+ * @returns `true` if a key was deleted, `false` if none matched (already revoked / never created).
+ */
+export async function revokeKey(
+  db: D1Database,
+  membershipId: string,
+): Promise<boolean> {
+  const result = await db
+    .prepare("delete from enterprise_keys where whop_membership_id = ?")
+    .bind(membershipId)
+    .run();
+
+  return (result.meta.changes ?? 0) > 0;
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -99,4 +99,6 @@ export type HonoApp = { Bindings: Bindings };
 export type Bindings = {
   DB: D1Database; // geolite2 (unchanged)
   ENTERPRISE_DB: D1Database; // enterprise keys + usage
+  WHOP_WEBHOOK_SECRET: string; // Whop webhook signing secret (verifies incoming webhooks)
+  WHOP_API_KEY?: string; // only used to satisfy the @whop/sdk constructor; no API calls are made for now
 };


### PR DESCRIPTION
**Needs QA testing**

Whop membership.activated/deactivated webhooks now create and revoke enterprise keys, replacing the manual SQL workflow for individual subscribers. We reuse the license key Whop issues per membership (storing only its hash) so the customer reads it from their Whop dashboard, and gate access on a whop_plans product allowlist.